### PR TITLE
Remove whitespace around pasted content

### DIFF
--- a/resources/views/paste.blade.php
+++ b/resources/views/paste.blade.php
@@ -10,9 +10,7 @@
     <div class="small-12 medium-8 columns show-bin-content">
         <h3>{{ $paste->title }}</h3>
 
-        <pre class="line-numbers">
-            <code class="language-phplinks">{{ $paste->content }}</code>
-        </pre>
+        <pre class="line-numbers"><code class="language-phplinks">{{ $paste->content }}</code></pre>
     </div>
 
     @if( ! empty( $tags ) )


### PR DESCRIPTION
The output of pasted content includes leading and trailing whitespace which is not entered by the user.

* Remove leading and trailing whitespace in `<pre>` element.

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>