### PR TITLE
Cleanup the paste view code CSS

### DIFF
--- a/public/css/wpbin.css
+++ b/public/css/wpbin.css
@@ -14759,6 +14759,8 @@ pre.line-numbers > code {
 }
 
 #content .show-bin .show-bin-content pre.line-numbers > code {
+  background: none;
+  border: none;
   position: initial;
 }
 

--- a/resources/sass/pages/_paste.scss
+++ b/resources/sass/pages/_paste.scss
@@ -12,7 +12,8 @@
 
 
         pre.line-numbers > code {
-
+            background: none;
+            border: none;
             position: initial;
         }
 


### PR DESCRIPTION
* Remove the background and border

This removes the weird line-border-only-the-length-of-each-line visual.

Before:
![image](https://user-images.githubusercontent.com/147548/83973858-11ebde80-a8e1-11ea-8f01-3e211a3b96a7.png)
After:
![image](https://user-images.githubusercontent.com/147548/83973864-2203be00-a8e1-11ea-8fa1-cddcf03e9bb1.png)

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>